### PR TITLE
Fixing a bug with role check

### DIFF
--- a/src/DiscordBot/Modules/FeedbackHandlingModule.cs
+++ b/src/DiscordBot/Modules/FeedbackHandlingModule.cs
@@ -149,10 +149,10 @@ namespace DiscordBot.Modules
         private bool IsMessagingUserOfficer()
         {
             var user = Context.Message.Author;
-            var userRoles = GetMessagingUser()?.Roles;
+            var guildRoles = GetMessagingUser()?.Guild?.Roles;
             // Configurable by guild in future release 
             var officerLevelRoles = new List<string> { "officer", "raidleader" };
-            return userRoles != null && userRoles.Any(role => officerLevelRoles.Any(olr => string.Equals(role.Name, olr, StringComparison.OrdinalIgnoreCase)));
+            return guildRoles != null && guildRoles.Any(role => officerLevelRoles.Any(olr => string.Equals(role.Name, olr, StringComparison.OrdinalIgnoreCase)));
         }
 
         private SocketGuildUser GetMessagingUser()


### PR DESCRIPTION
Fixing an issue where role check was checking the users role in context of themselves, not in context of the Guild